### PR TITLE
(doc) Fix formatting of markdown

### DIFF
--- a/packaging/choco/nvml-exporter/nvml-exporter.nuspec
+++ b/packaging/choco/nvml-exporter/nvml-exporter.nuspec
@@ -17,21 +17,21 @@
     <summary>NVML Exporter for Prometheus</summary>
     <description>This package installs an NVML exporter for NVIDIA GPU metrics via the Prometheus metrics data format.
 
-    ## Configuration
+## Configuration
 
-    You can change the port used for listening (default=9996):
+You can change the port used for listening (default=9996):
 
-    ```
-    --params "'/ListenPort:12345'"
-    ```
+```
+--params "'/ListenPort:12345'"
+```
 
-    You can also enable collection of GPU throttling reasons (disabled by default):
+You can also enable collection of GPU throttling reasons (disabled by default):
 
-    ```
-    --params "'/EnableThrottleReasons'"
-    ```
+```
+--params "'/EnableThrottleReasons'"
+```
 
-    ECC memory error collection is disabled unless ECC memory is available and currently in ECC mode. GeForce GPUs do not have ECC memory.
+ECC memory error collection is disabled unless ECC memory is available and currently in ECC mode. GeForce GPUs do not have ECC memory.
     </description>
     <releaseNotes>https://github.com/oko/nvml-exporter-rs/releases</releaseNotes>
   </metadata>


### PR DESCRIPTION
This will ensure that the markdown renders correctly when displayed on the Chocolatey Community Repository.

Rather than what is currently being shown:

![image](https://github.com/oko/nvml-exporter-rs/assets/1271146/5f995ee1-a038-4678-993f-88722026e8d0)
